### PR TITLE
Small changes to the example & added a missing semicolon.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,11 @@ Example:
 
     $ipaddr = "127.0.0.1";
     $port = "5121";
-    @include $server_check.php
+    $timeout = 5;
+    include "server_check.php";
 
      if ($nwn_online) {
-        echo "Server online!" 
+        echo "Server online!";
         echo "Server name: $nwn_server";
         echo "Players Online: $nwn_players";
      } else {
@@ -45,7 +46,7 @@ Useful supported variables to include in your code are:
 
 ``$nwn_players``    Players logged in and players limit (ex. 10/30)
 
-``$nwn_players_online`` Amount of players actually online
+``$nwn_players_online`` Players actually online
 
 ``$nwn_players_max``    Max limit of players allowed to join
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Useful supported variables to include in your code are:
 
 ``$nwn_players``    Players logged in and players limit (ex. 10/30)
 
-``$nwn_players_online`` Players actually online
+``$nwn_players_online`` Number of players online
 
 ``$nwn_players_max``    Max limit of players allowed to join
 


### PR DESCRIPTION
Those are the changes I had to make to the example to make it work on my own system.

`$timeout = 5;` could probably be moved to the server_check.php if you wish to keep the example smaller. And there is rarely ever a need to change this.
But I'd keep it in the example, as there is no way to change it before you include the check file. Unless you made the check into a function. But that would again complicate it more.